### PR TITLE
i18n: localize controls and add Arabic translations

### DIFF
--- a/i18n/ar.toml
+++ b/i18n/ar.toml
@@ -1,0 +1,5 @@
+[carousel_next]
+other = "التالي"
+
+[carousel_previous]
+other = "السابق"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -1,0 +1,5 @@
+[carousel_next]
+other = "Next"
+
+[carousel_previous]
+other = "Previous"

--- a/layouts/partials/hb/modules/carousel/controls.html
+++ b/layouts/partials/hb/modules/carousel/controls.html
@@ -5,7 +5,7 @@
     href="#{{ . }}"
     data-bs-slide="prev">
     {{- partial "icons/icon" (dict "vendor" "bs" "name" "arrow-left-circle" "height" "1.75em" "width" "1.75em") -}}
-    <span class="visually-hidden">Previous</span>
+    <span class="visually-hidden">{{ i18n "carousel_previous" }}</span>
   </a>
   <a
     class="carousel-control"
@@ -13,6 +13,6 @@
     href="#{{ . }}"
     data-bs-slide="next">
     {{- partial "icons/icon" (dict "vendor" "bs" "name" "arrow-right-circle" "height" "1.75em" "width" "1.75em") -}}
-    <span class="visually-hidden">Next</span>
+    <span class="visually-hidden">{{ i18n "carousel_next" }}</span>
   </a>
 </div>


### PR DESCRIPTION
## Summary

- replace hardcoded carousel control labels with translation keys
- preserve the existing English labels in a translation catalog
- add Arabic labels for previous and next controls

## Why

The visually hidden control labels are currently always English, including on Arabic sites.

## Validation

- rendered the carousel controls in Arabic and English with Hugo 0.146.5
- built with `--printI18nWarnings`; no warnings for the added keys

The repository's existing lint command currently stops because ESLint 10 cannot find a configuration file.
